### PR TITLE
INSTALL: mention tmux workingness

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,6 +17,8 @@ Install the launchd configuration:
 
   $ make install-plist
 
+Note that the above command may not work if run from a tmux session.
+
 *** BEGIN Mavericks only BEGIN ****
 
 This last step will pop-up a dialog saying something like:


### PR DESCRIPTION
`launchctl` and `tmux` don't get along (see the literature for
hacks like `reattach-to-user-namespace`, etc), causing the
`make install-plist` to fail when run under `tmux`.  Warn
unsuspecting users of this pitfall.
